### PR TITLE
6-start-fixes

### DIFF
--- a/composables/useWallet.ts
+++ b/composables/useWallet.ts
@@ -8,7 +8,6 @@ const chain = ref<IPactCommand["meta"]["chainId"]>("0");
 const instance = ref<any>(null);
 const publicKey = ref<null | string>(null);
 const account = ref<null | string>("");
-const connectedSites = ref<any[]>([]);
 const isInstalled = ref(false);
 const isConnected = computed(() => account.value && publicKey.value);
 
@@ -18,20 +17,13 @@ export function useWallet() {
       console.warn("Kadena Wallet is not installed");
     }
   });
-  const checkIdWalletIsInstalled = () => {
+  const checkIfWalletIsInstalled = () => {
     if (initialized.value) return;
     // @ts-expect-error - ecko wallet (kadena) may not be installed
     const { kadena } = window;
     isInstalled.value = Boolean(kadena && kadena.isKadena);
     instance.value = kadena;
     initialized.value = true;
-  };
-
-  const initialize = async () => {
-    checkIdWalletIsInstalled();
-    if (isInstalled.value) {
-      // You will start here
-    }
   };
 
   const connect = async () => {
@@ -42,7 +34,7 @@ export function useWallet() {
       });
 
       if (status === "success") {
-        await setAccount(account);
+        setAccount(account);
       }
 
       return { account, status };
@@ -52,22 +44,9 @@ export function useWallet() {
   const setAccount = (data: {
     account: string | null;
     publicKey: string | null;
-    connectedSites: any[];
   }) => {
     account.value = data.account;
     publicKey.value = data.publicKey;
-    connectedSites.value = data.connectedSites;
-  };
-
-  const requestAccount = async () => {
-    if (isInstalled.value && instance.value) {
-      const response = await instance?.value.request({
-        method: "kda_requestAccount",
-        networkId: networkId.value,
-      });
-      console.log("kda_requestAccount", response);
-      return response;
-    }
   };
 
   const checkStatus = async () => {
@@ -92,7 +71,7 @@ export function useWallet() {
           networkId: networkId.value,
         });
         console.log("disconnect response", response);
-        setAccount({ account: null, publicKey: null, connectedSites: [] });
+        setAccount({ account: null, publicKey: null });
         return response;
       }
     }
@@ -131,7 +110,6 @@ export function useWallet() {
       method: "kda_requestQuickSign",
       data: {
         networkId: networkId.value,
-        // signingCmd: signingRequest,
         commandSigDatas: [
           {
             sigs: [
@@ -163,25 +141,17 @@ export function useWallet() {
     }
   });
 
-  initialize().then(() => {
-    instance.value?.on("res_accountChange", (event: any) => {
-      console.log(event);
-    });
-  });
-
+  checkIfWalletIsInstalled();
   return {
     connect,
     disconnect,
     checkStatus,
-
     signTransaction,
 
     balance: computed(() => balance.value),
-    initialized: computed(() => initialized.value),
     isConnected,
     account: computed(() => account.value),
     publicKey: computed(() => publicKey.value),
-    connectedSites: computed(() => connectedSites.value),
     chain: computed(() => chain.value),
     networkId: computed(() => networkId.value),
     instance: computed(() => instance.value),

--- a/package.json
+++ b/package.json
@@ -6,17 +6,16 @@
     "supabase:start": "npx supabase start",
     "supabase:stop": "npx supabase stop",
     "dev": "nuxt dev",
-    "generate:kda:types": "npx pactjs contract-generate --contract=free.crowdfund --api=https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/0/pact",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "db:reset": "npx supabase db reset && yarn db:types",
+    "db:reset": "npx supabase db reset && npm run db:types",
     "db:types": "supabase gen types typescript --local > ./supabase/schema.ts",
     "kadena:devnet": "docker run -it -p 8080:1337 -v $HOME/.devnet/l1:/root/.devenv enof/devnet",
     "kadena:cli": "docker run --rm -it -v $(pwd):/app/ --add-host=devnet:host-gateway enof/kda-cli",
-    "kadena:types": "npx pactjs contract-generate --contract=free.crowdfund --api=https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/0/pact",
-    "kadena:fund": "yarn kadena:cli --profile=.fund-profile.json",
-    "kadena:deploy": "yarn kadena:cli --profile=.deploy-profile.json"
+    "kadena:types": "npx pactjs contract-generate --contract=free.crowdfund --api=https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/0/pact && npx pactjs contract-generate --contract=free.crowdfund --api=https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/0/pact",
+    "kadena:fund": "npm run kadena:cli -- --profile=.fund-profile.json",
+    "kadena:deploy": "npm run kadena:cli -- --profile=.deploy-profile.json"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",


### PR DESCRIPTION
- Fixed the typings for the createTransaction function
- Removed connectedSites as it's not used and can cause misunderstandings
- It's best practice to use the account returned from the wallet instead of prepending `k:`. You can rotate your public key but keep your account, so you can never be 100% sure that the part behind `k:` is the current public key.
- Changed yarn to npm for the scripts in package.json, as most people will have npm while it could be that some do not have yarn.